### PR TITLE
Fixed final RF score returned

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,11 +1,13 @@
 cmake_minimum_required (VERSION 2.6)
 project (FastRFS)
-OPTION(BUILD_STATIC "build static" ON)
+OPTION(BUILD_STATIC "build static" OFF)
 OPTION(BUILD_SHARED "build shared" ON)
 file(GLOB SOURCES *.cpp)
 
 add_definitions(-std=c++14 -g -O3 -Wall)
-
+include_directories("../../install/include"
+                    "../../install/include/phylonaut")
+link_directories("../../install/lib")
 
 if (BUILD_SHARED)
 	add_executable(FastRFS ${SOURCES} FastRFS.cpp)

--- a/src/FastRFTripartitionScorer.hpp
+++ b/src/FastRFTripartitionScorer.hpp
@@ -9,10 +9,12 @@ class FastRFTripartitionScorer : public TripartitionScorer {
 public:
   FastRFTripartitionScorer(string genetreesfile) : treesfile(genetreesfile) {};
   void setup(Config& conf, vector<Clade>& clades);
-  int addSourceTree(string tree);
+  void addSourceTree(string tree);
   virtual double score (const Tripartition& t);
   bool matches(const Tripartition& t, const Bipartition& bp);
   int total_weight;
+  int total_leaves;
+  int n_trees;
   virtual double adjust_final_score(double score);
   virtual bool better(double newscore, double oldscore);
 private:


### PR DESCRIPTION
only necessary for unresolved input trees (doesn't impact optimization phase)